### PR TITLE
Fix manifest file

### DIFF
--- a/deployments/sltd.yaml
+++ b/deployments/sltd.yaml
@@ -17,14 +17,14 @@ spec:
       containers:
       - image: "quay.io/koudaiii/sltd:latest"
         name: sltd
-          resources:
-            requests:
-              cpu: 100m
-              memory: 30Mi
-          command:
-            - "/sltd"
-          args:
-            - "--sync-interval=60"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 30Mi
+        command:
+          - "/sltd"
+        args:
+         - "--sync-interval=60s"
         env:
         - name: AWS_DEFAULT_REGION
           value: "ap-northeast-1"


### PR DESCRIPTION
## WHY

```
$ kubectl logs sltd-XXXXX
invalid argument "60" for --sync-interval=60: time: missing unit in duration 60
      --in-cluster               If true, use the built in kubernetes cluster for creating the client (default true)
      --onetime                  run one time and exit.
      --sync-interval duration   the time duration between template processing. (default 1m0s)
  -v, --version                  Print version
```

