### PR TITLE
Update labels to Datadog format

### DIFF
--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -57,9 +57,13 @@ func (c *KubeClient) GetAllServices(namespaces *v1.NamespaceList) (services []Se
 	return services, nil
 }
 
-func (c *KubeClient) UpdateLabelsKubernetesCluster(elbTags []Label, service Service) Service {
+func (c *KubeClient) UpdateLabelsToDataDogFormat(elbTags []Label, service Service) Service {
+
+	for _, s := range service.Labels {
+		s.Key = "kube_" + s.Key
+	}
 	service.Labels = append(service.Labels, Label{
-		Key:   "kube_name",
+		Key:   "kube_service",
 		Value: service.KubeName,
 	})
 	service.Labels = append(service.Labels, Label{

--- a/tag.go
+++ b/tag.go
@@ -41,7 +41,7 @@ func (c *Client) process() {
 			log.Println(err)
 			return
 		}
-		c.attachELBTags(tags, c.kubeclient.UpdateLabelsKubernetesCluster(exchangeTypeFromTagsToLabels(tags), s))
+		c.attachELBTags(tags, c.kubeclient.UpdateLabelsToDataDogFormat(exchangeTypeFromTagsToLabels(tags), s))
 	}
 }
 


### PR DESCRIPTION
## WHY

Update labels Datadog format

## WHAT

- service_name

```
{
key: "kube_service",
value: kubenetes.io/service-name,
}
```

- kubernetescluster

```
{
key: "kubernetescluster",
value: cluster name,
}
```

- labels

```
{
key: "kube_" + key,
value: value,
}
```



