### PR TITLE
Remove debug prints

### DIFF
--- a/aws/elb/elb.go
+++ b/aws/elb/elb.go
@@ -1,8 +1,6 @@
 package elb
 
 import (
-	"log"
-
 	awspkg "github.com/koudaiii/sltd/aws"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,12 +58,11 @@ func (c *AwsClient) AddTag(name string, tag *Tag) error {
 		},
 	}
 
-	result, err := c.client.AddTags(input)
+	_, err := c.client.AddTags(input)
 	if err != nil {
 		return err
 	}
 
-	log.Println(result)
 	return nil
 }
 
@@ -81,11 +78,10 @@ func (c *AwsClient) DeleteTag(name string, key string) error {
 		},
 	}
 
-	result, err := c.client.RemoveTags(input)
+	_, err := c.client.RemoveTags(input)
 	if err != nil {
 		return err
 	}
 
-	log.Println(result)
 	return nil
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -39,7 +39,6 @@ func NewKubeClient(inCluster bool) *KubeClient {
 		log.Printf("service host: %s", config.Host)
 
 		clientset, err := kubernetes.NewForConfig(config)
-		log.Println(clientset)
 		if err != nil {
 			log.Fatalln(err)
 			os.Exit(1)

--- a/tag.go
+++ b/tag.go
@@ -20,20 +20,17 @@ func NewClient(inCluster bool) *Client {
 }
 
 func (c *Client) process() {
-
 	namespaces, err := c.kubeclient.GetAllNamespaces()
 	if err != nil {
 		log.Fatalln(err)
 		return
 	}
-	log.Println(namespaces)
 
 	svc, err := c.kubeclient.GetAllServices(namespaces)
 	if err != nil {
 		log.Fatalln(err)
 		return
 	}
-	log.Println(svc)
 
 	for _, s := range svc {
 		// log.Println(s)
@@ -47,8 +44,6 @@ func (c *Client) process() {
 }
 
 func (c *Client) attachELBTags(tags []elb.Tag, service kubernetes.Service) error {
-	log.Println(tags)
-	log.Println(service)
 	for _, s := range service.Labels {
 		alreadyTag := false
 
@@ -72,10 +67,8 @@ func (c *Client) attachELBTags(tags []elb.Tag, service kubernetes.Service) error
 		}
 		if alreadyTag {
 			log.Println("skip. ELB Already tagged.")
-			log.Println(labelToTag)
 		} else {
 			log.Println("Add Tag")
-			log.Println(s)
 			c.awsclient.AddTag(service.Name, labelToTag)
 		}
 	}


### PR DESCRIPTION
## WHY

sltd prints some Go variables for debug. Actually these are hard to read.

```
2017/11/21 09:25:32 [{kubernetes.io/service-name echo/echo} {kube_name echo} {kubernetes.io/cluster/example.com owned} {role web} {kube_service echo} {kube_role web} {name furiganer} {KubernetesCluster example.com} {kube_namespace echo} {kubernetescluster example.com}]
```

Especially `log.Println(namespaces)` prints a lot of fields, in addition to "name of namespace".

These logs are printed forcibly, so these make noise on production log.

## WHAT

Remove all debug prints that prints raw form of Go variables.

If we really want them for debug, log level can be switched by environment variable `LOG_LEVEL=debug`, using [logrus](https://github.com/sirupsen/logrus) or [zap](https://github.com/uber-go/zap).