### PR TITLE
Fix process

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -22,14 +22,12 @@ func isNotExists() bool {
 func NewKubeClient(inCluster bool) *KubeClient {
 	if isNotExists() && !(inCluster) {
 		log.Fatalln("kubeconfig invalid and --in-cluster is false; kubeconfig must be set to a valid file(kubeconfig default file name: $HOME/.kube/config)")
-		os.Exit(1)
 	}
 
 	if inCluster {
 		config, err := rest.InClusterConfig()
 		if err != nil {
 			log.Fatalln(err)
-			os.Exit(1)
 		}
 		tokenPresent := false
 		if len(config.BearerToken) > 0 {
@@ -41,7 +39,6 @@ func NewKubeClient(inCluster bool) *KubeClient {
 		clientset, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			log.Fatalln(err)
-			os.Exit(1)
 		}
 
 		log.Println("Testing communication with server")
@@ -49,7 +46,6 @@ func NewKubeClient(inCluster bool) *KubeClient {
 
 		if err != nil {
 			log.Fatalln(err)
-			os.Exit(1)
 		}
 		log.Println("Communication with server successful")
 
@@ -66,21 +62,17 @@ func NewKubeClient(inCluster bool) *KubeClient {
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
-	// log.Println(clientset)
 	if err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 
 	log.Println("Testing communication with server")
 	_, err = clientset.Discovery().ServerVersion()
 	if err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 	log.Println("Communication with server successful")
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ func main() {
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 
 	if version {

--- a/tag.go
+++ b/tag.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/koudaiii/sltd/aws/elb"
 	"github.com/koudaiii/sltd/kubernetes"
@@ -22,13 +24,13 @@ func NewClient(inCluster bool) *Client {
 func (c *Client) process() {
 	namespaces, err := c.kubeclient.GetAllNamespaces()
 	if err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 
 	svc, err := c.kubeclient.GetAllServices(namespaces)
 	if err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 
@@ -36,7 +38,7 @@ func (c *Client) process() {
 		// log.Println(s)
 		tags, err := c.awsclient.DescribeTags(s.Name)
 		if err != nil {
-			log.Fatalln(err)
+			fmt.Fprintln(os.Stderr, err)
 			return
 		}
 		c.attachELBTags(tags, c.kubeclient.UpdateLabelsToDataDogFormat(exchangeTypeFromTagsToLabels(tags), s))


### PR DESCRIPTION
## WHY

tag.go should not be stop process by os.Exit(1).
Because processing is interrupted halfway

## WHAT

- Delete redundant code
- fix tag.go

```
$ ./bin/sltd --in-cluster=false --onetime
2017/11/22 13:41:01 Testing communication with server
2017/11/22 13:41:02 Communication with server successful
2017/11/22 13:41:11 skip. ELB Already tagged.
2017/11/22 13:41:11 skip. ELB Already tagged.
2017/11/22 13:41:11 skip. ELB Already tagged.
2017/11/22 13:41:11 skip. ELB Already tagged.
・・・
```
