### PR TITLE
Using RBAC

### DIFF
--- a/deployments/sltd.yaml
+++ b/deployments/sltd.yaml
@@ -40,3 +40,36 @@ spec:
             secretKeyRef:
               name: dotenv
               key: aws-secret-access-key
+      serviceAccount: sltd
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: sltd
+rules:
+- apiGroups: [""]
+  resources:
+    - "namespaces"
+  verbs: ["list"]
+- apiGroups: [""]
+  resources:
+  - "services"
+  verbs: ["get", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sltd
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: sltd
+subjects:
+- kind: ServiceAccount
+  name: sltd
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: sltd
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## WHY

```
2018/04/20 02:24:04 Starting sltd...
2018/04/20 02:24:04 namespaces is forbidden: User "system:serviceaccount:default:default" cannot list namespaces at the cluster scope
```

if k8s >= 1.8 is, does not work sltd.

## WHAT

Using RBAC