### PR TITLE
Fix docker login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bin/$(NAME): $(SRCS)
 
 .PHONY: ci-docker-release
 ci-docker-release: docker-build
-	@docker login -e="$(DOCKER_QUAY_EMAIL)" -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
+	@docker login -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
 	docker push $(DOCKER_IMAGE)
 
 .PHONY: clean


### PR DESCRIPTION
## WHY

```
docker build -t quay.io/[secure]/sltd:latest .
Sending build context to Docker daemon     28MB
Step 1/5 : FROM alpine:3.6
3.6: Pulling from library/alpine
605ce1bd3f31: Pulling fs layer
605ce1bd3f31: Verifying Checksum
605ce1bd3f31: Download complete
605ce1bd3f31: Pull complete
Digest: sha256:3d44fa76c2c83ed9296e4508b436ff583397cac0f4bad85c2b4ecc193ddb5106
Status: Downloaded newer image for alpine:3.6
 ---> 77144d8c6bdc
Step 2/5 : RUN apk add --no-cache --update ca-certificates
 ---> Running in 8a01ea289fcf
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20161130-r2)
Executing busybox-1.26.2-r9.trigger
Executing ca-certificates-20161130-r2.trigger
OK: 5 MiB in 12 packages
 ---> 68d111d4a0f6
Removing intermediate container 8a01ea289fcf
Step 3/5 : COPY bin/sltd /sltd
 ---> bac274ab5969
Step 4/5 : ENTRYPOINT /sltd
 ---> Running in b2a5b4c98da9
 ---> 34c9380f853d
Removing intermediate container b2a5b4c98da9
Step 5/5 : CMD help
 ---> Running in cdafd7660454
 ---> 73641af2db97
Removing intermediate container cdafd7660454
Successfully built 73641af2db97
Successfully tagged quay.io/[secure]/sltd:latest
unknown shorthand flag: 'e' in -e=[secure]
See 'docker login --help'.
make: *** [ci-docker-release] Error 125
Script failed with status 2
failed to deploy
```

Deprecated `-e` option

## WHAT

- delete option